### PR TITLE
fix(hooks): paths vars not exported properly in fish

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
         if: "${{ matrix.os == 'macos-latest' }}"
         uses: actions/cache@v3
         with:
-          path: ${{ env.DENO_DIR }}
+          path: ${{ env.GHJK_DENO_DIR }}
           key: deno-mac-${{ hashFiles('**/deno.lock') }}
 
       - if: "${{ matrix.e2eType == 'docker' }}"

--- a/install/ghjk.sh
+++ b/install/ghjk.sh
@@ -1,6 +1,7 @@
 #!/bin/sh 
 export GHJK_SHARE_DIR="${GHJK_SHARE_DIR:-__GHJK_SHARE_DIR__}" 
 export DENO_DIR="${GHJK_DENO_DIR:-__DENO_CACHE_DIR}" 
+export DENO_NO_UPDATE_CHECK=1
 
 # if ghjkfile var is set, set the GHJK_DIR overriding
 # any set by the user

--- a/install/hook.sh
+++ b/install/hook.sh
@@ -62,7 +62,6 @@ export GHJK_LAST_PWD="$PWD"
 
 precmd() {
     if [ "$GHJK_LAST_PWD" != "$PWD" ]; then
-        echo "reloading"
         ghjk_reload
         export GHJK_LAST_PWD="$PWD"
     fi

--- a/modules/ports/sync.ts
+++ b/modules/ports/sync.ts
@@ -1087,8 +1087,8 @@ export ${k}="${v}:$${k}";
 set --global --export ${k} '${v}';`
       ),
       ...Object.entries(pathVars).map(([k, v]) =>
-        `set --global --append GHJK_CLEANUP_FISH 'set --global --path ${k} (string match --invert --regex "^${envDir}" $${k});';
-set --global --prepend ${k} ${v};
+        `set --global --append GHJK_CLEANUP_FISH 'set --global --export --path ${k} (string match --invert --regex "^${envDir}" $${k});';
+set --global --export --prepend ${k} ${v};
 `
       ),
     ].join("\n"),

--- a/tests/hooks.ts
+++ b/tests/hooks.ts
@@ -8,11 +8,14 @@ import {
 import dummy from "../ports/dummy.ts";
 import type { InstallConfigFat } from "../port.ts";
 
-// avoid using single quotes in this script
 const posixInteractiveScript = `
 set -eux
 [ "$DUMMY_ENV" = "dummy" ] || exit 101
 dummy
+
+# it should be avail in subshells
+sh -c '[ "$DUMMY_ENV" = "dummy" ]' || exit 105
+sh -c "dummy"
 
 pushd ../
 # it shouldn't be avail here
@@ -59,7 +62,6 @@ ${line}
 ]
   .join("\n");
 
-// avoid using single quotes in this script
 const posixNonInteractiveScript = `
 set -eux
 
@@ -67,6 +69,10 @@ set -eux
 ghjk_reload
 [ "$DUMMY_ENV" = "dummy" ] || exit 101
 dummy
+
+# it should be avail in subshells
+sh -c '[ "$DUMMY_ENV" = "dummy" ]' || exit 105
+sh -c "dummy"
 
 pushd ../
 # no reload so it's stil avail
@@ -93,6 +99,10 @@ dummy
 const fishScript = `
 dummy; or exit 101
 test $DUMMY_ENV = "dummy"; or exit 102
+
+# it should be avail in subshells
+sh -c '[ "$DUMMY_ENV" = "dummy" ]'; or exit 105
+sh -c "dummy"
 
 pushd ../
 # it shouldn't be avail here


### PR DESCRIPTION
Fixed bug in the fish hook around how the path variables are exported.

### Motivation and context

The paths not being exported means that any program/subshells launched from within this context won't contain those vars. I run into this when the dynamic linker refused to locate a library despite the contents of `$LD_LIBRARY_PATH`. 

### Migration notes

*No change required*.

### Checklist

- [x] The change come with new or modified tests
- [ ] ~~Hard-to-understand functions have explanatory comments~~
- [ ] ~~End-user documentation is updated to reflect the change~~
