### PR TITLE
feat(ports): `opentofu_ghrel`

### DIFF
--- a/ports/mod.ts
+++ b/ports/mod.ts
@@ -11,6 +11,7 @@ export { default as meta_cli_ghrel } from "./meta_cli_ghrel.ts";
 export { default as mold } from "./mold.ts";
 export { default as node } from "./node.ts";
 export { default as npmi } from "./npmi.ts";
+export { default as opentofu_ghrel } from "./opentofu_ghrel.ts";
 export { default as pipi } from "./pipi.ts";
 export { default as pnpm } from "./pnpm.ts";
 export { default as protoc } from "./protoc.ts";

--- a/ports/opentofu_ghrel.ts
+++ b/ports/opentofu_ghrel.ts
@@ -1,0 +1,84 @@
+import {
+  $,
+  DownloadArgs,
+  dwnUrlOut,
+  GithubReleasePort,
+  InstallArgs,
+  type InstallConfigSimple,
+  osXarch,
+  std_fs,
+  std_path,
+  unarchive,
+} from "../port.ts";
+import { GithubReleasesInstConf, readGhVars } from "../modules/ports/ghrel.ts";
+
+const manifest = {
+  ty: "denoWorker@v1" as const,
+  name: "opentofu_ghrel",
+  version: "0.1.0",
+  moduleSpecifier: import.meta.url,
+  platforms: osXarch(
+    ["linux", "darwin", "freebsd", "windows", "solaris"],
+    ["aarch64", "x86_64"],
+  ),
+};
+
+export default function conf(
+  config: InstallConfigSimple & GithubReleasesInstConf = {},
+) {
+  return {
+    ...readGhVars(),
+    ...config,
+    port: manifest,
+  };
+}
+
+export class Port extends GithubReleasePort {
+  repoOwner = "opentofu";
+  repoName = "opentofu";
+
+  downloadUrls(args: DownloadArgs) {
+    const { installVersion, platform } = args;
+
+    let arch;
+    switch (platform.arch) {
+      case "x86_64":
+        arch = "amd64";
+        break;
+      case "aarch64":
+        arch = "arm64";
+        break;
+      default:
+        throw new Error(`unsupported platform: ${platform}`);
+    }
+    const os = platform.os;
+
+    return [
+      this.releaseArtifactUrl(
+        installVersion,
+        `tofu_${
+          installVersion.startsWith("v")
+            ? installVersion.slice(1)
+            : installVersion
+        }_${os}_${arch}.zip`,
+      ),
+    ].map(dwnUrlOut);
+  }
+
+  async install(args: InstallArgs) {
+    const [{ name: fileName }] = this.downloadUrls(args);
+    const fileDwnPath = std_path.resolve(args.downloadPath, fileName);
+
+    await unarchive(fileDwnPath, args.tmpDirPath);
+
+    const installPath = $.path(args.installPath);
+    if (await installPath.exists()) {
+      await installPath.remove({ recursive: true });
+    }
+
+    await std_fs.copy(
+      args.tmpDirPath,
+      installPath.join("bin").toString(),
+    );
+  }
+}

--- a/tests/ports.ts
+++ b/tests/ports.ts
@@ -70,6 +70,12 @@ const cases: CustomE2eTestCase[] = [
     installConf: ports.temporal_cli(),
     ePoint: `temporal --version`,
   },
+  // 23 megs
+  {
+    name: "opentofu",
+    installConf: ports.opentofu_ghrel(),
+    ePoint: `tofu --version`,
+  },
   // 24 megs
   {
     name: "terraform",

--- a/utils/mod.ts
+++ b/utils/mod.ts
@@ -10,7 +10,6 @@ import logger, { isColorfulTty } from "./logger.ts";
 // NOTE: only use type imports only when getting stuff from "./modules"
 import type {
   DepArts,
-  DownloadArgs,
   InstallConfigFat,
   InstallConfigResolvedX,
   OsEnum,
@@ -333,7 +332,9 @@ exec ${execPath}${defArgs ? ` ${defArgs}` : ""} $*`,
   );
 }
 
-export type DownloadFileArgs = DownloadArgs & {
+export type DownloadFileArgs = {
+  downloadPath: string;
+  tmpDirPath: string;
   url: string;
   name?: string;
   mode?: number;


### PR DESCRIPTION
Adds a port for `opentofu` that pulls from their github release builds.

### Motivation and context

Alternative to `terraform` to be used in the metatype cloud console.

### Migration notes

__No changes required__

### Checklist

- [x] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
