### PR TITLE
fix(port): `cpy_bs` doesn't work on arm

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,25 @@ jobs:
       
       - run: deno task test
 
+  test-e2e-compat:
+    runs-on: macos-14
+    container:
+      image: debian:12
+      options: --platform linux/arm64
+    env:
+      GHJK_TEST_E2E_TYPE: "local"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v1
+        with:
+          deno-version: ${{ env.DENO_VERSION }}
+      - name: Cache deno dir
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.DENO_DIR }}
+          key: deno-linux-${{ hashFiles('**/deno.lock') }}
+      - run: deno task test
+
   test-action:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
+            platform: linux/amd64
+            e2eType: "docker"
+          - os: custom-macos
+            platform: linux/arm64
             e2eType: "docker"
           - os: macos-latest
+            platform: darwin/amd64
             e2eType: "local"
           - os: macos-14
+            platform: darwin/arm64
             e2eType: "local"
           # - os: windows-latest
           #   e2eType: "local"
@@ -62,7 +68,9 @@ jobs:
       - if: "${{ matrix.os == 'macos-latest' || matrix.os == 'macos-14' }}"
         # we need coreutils on max for the `timeout` command
         run: brew install fish zsh coreutils
-      - run: deno task test
+      - env: 
+          DOCKER_PLATFORM: linux/arm64
+        run: deno task test
 
   test-e2e-compat:
     runs-on: custom-macos

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,13 +38,13 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            platform: linux/amd64
+            platform: linux/x86_64
             e2eType: "docker"
           - os: custom-macos
-            platform: linux/arm64
+            platform: linux/aarch64
             e2eType: "docker"
           - os: macos-latest
-            platform: darwin/amd64
+            platform: darwin/x86_64
             e2eType: "local"
           - os: macos-14
             platform: darwin/arm64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,11 +64,6 @@ jobs:
           key: deno-mac-${{ hashFiles('**/deno.lock') }}
       - if: "${{ matrix.e2eType == 'docker' }}"
         uses: docker/setup-buildx-action@v3
-      - if: "${{ matrix.e2eType == 'docker' }}"
-        uses: actions-hub/docker/cli@master
-        env:
-          SKIP_LOGIN: true
-      
       - run: deno task test
 
   test-e2e-compat:
@@ -81,14 +76,11 @@ jobs:
         with:
           deno-version: ${{ env.DENO_VERSION }}
       - uses: docker/setup-buildx-action@v3
-      - uses: actions-hub/docker/cli@master
-        env:
-          SKIP_LOGIN: true
       - shell: bash
         env:
           TAG: test-image
         run: |
-          docker buildx build --network=host --build-arg DENO_VERSION=$DENO_VERSION -t $TAG -f - .<<"DFILE"
+          docker buildx build --platform linux/arm64 --build-arg DENO_VERSION=$DENO_VERSION -t $TAG -f - .<<"DFILE"
             ARG DENO_VERSION=1.42.1
             FROM denoland/deno:bin-1.42.1 AS deno
             FROM debian:12
@@ -119,7 +111,7 @@ jobs:
             ENTRYPOINT deno task test
           DFILE
 
-          docker run -it --rm $TAG
+          docker run --platform linux/arm64 -it --rm $TAG
 
 
   test-action:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,20 +72,6 @@ jobs:
           DOCKER_PLATFORM: linux/arm64
         run: deno task test
 
-  test-e2e-compat:
-    runs-on: custom-macos
-    env:
-      GHJK_TEST_E2E_TYPE: "local"
-    steps:
-      - uses: actions/checkout@v4
-      - uses: denoland/setup-deno@v1
-        with:
-          deno-version: ${{ env.DENO_VERSION }}
-      - uses: docker/setup-buildx-action@v3
-      - env: 
-          DOCKER_PLATFORM: linux/arm64
-        run: deno task test
-
 
   test-action:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
             platform: darwin/x86_64
             e2eType: "local"
           - os: macos-14
-            platform: darwin/arm64
+            platform: darwin/aarch64
             e2eType: "local"
           # - os: windows-latest
           #   e2eType: "local"
@@ -69,7 +69,7 @@ jobs:
         # we need coreutils on max for the `timeout` command
         run: brew install fish zsh coreutils
       - env: 
-          DOCKER_PLATFORM: linux/arm64
+          DOCKER_PLATFORM: ${{ matrix.platform }}
         run: deno task test
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
       - run: deno task test
 
   test-e2e-compat:
-    runs-on: macos-14
+    runs-on: custom-macos
     container:
       image: debian:12
       options: --platform linux/arm64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,18 +52,16 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: ${{ env.DENO_VERSION }}
-
-      - if: "${{ matrix.os == 'macos-latest' || matrix.os == 'macos-14' }}"
-        # we need coreutils on max for the `timeout` command
-        run: brew install fish zsh coreutils
       - name: Cache deno dir
-        if: "${{ matrix.os == 'macos-latest' || matrix.os == 'macos-14' }}"
         uses: actions/cache@v4
         with:
           path: ${{ env.DENO_DIR }}
-          key: deno-mac-${{ hashFiles('**/deno.lock') }}
+          key: deno-${{ hashFiles('**/deno.lock') }}
       - if: "${{ matrix.e2eType == 'docker' }}"
         uses: docker/setup-buildx-action@v3
+      - if: "${{ matrix.os == 'macos-latest' || matrix.os == 'macos-14' }}"
+        # we need coreutils on max for the `timeout` command
+        run: brew install fish zsh coreutils
       - run: deno task test
 
   test-e2e-compat:
@@ -76,42 +74,9 @@ jobs:
         with:
           deno-version: ${{ env.DENO_VERSION }}
       - uses: docker/setup-buildx-action@v3
-      - shell: bash
-        env:
-          TAG: test-image
-        run: |
-          docker buildx build --platform linux/arm64 --build-arg DENO_VERSION=$DENO_VERSION -t $TAG -f - .<<"DFILE"
-            ARG DENO_VERSION=1.42.1
-            FROM denoland/deno:bin-1.42.1 AS deno
-            FROM debian:12
-            COPY --from=deno /deno /usr/local/bin/deno
-            RUN set -eux; \
-                apt-get update; \
-                apt install --no-install-recommends --assume-yes \
-                # ambient deps \
-                # TODO: explicit libarchive \
-                zstd \
-                tar \
-                # TODO: explicit cc \
-                build-essential \
-                # test deps \
-                bash \
-                fish \
-                zsh \
-                # asdf deps \
-                git \
-                curl \
-                xz-utils \
-                unzip \
-                ca-certificates \
-                ;
-            WORKDIR /ghjk
-            COPY . .
-            ENV GHJK_TEST_E2E_TYPE=local
-            ENTRYPOINT deno task test
-          DFILE
-
-          docker run --platform linux/arm64 -it --rm $TAG
+      - env: 
+          DOCKER_PLATFORM: linux/arm64
+        run: deno task test
 
 
   test-action:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
       - run: deno task test
 
   test-e2e-compat:
-    runs-on: macos-14
+    runs-on: custom-macos
     env:
       GHJK_TEST_E2E_TYPE: "local"
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,10 +72,7 @@ jobs:
       - run: deno task test
 
   test-e2e-compat:
-    runs-on: custom-macos
-    container:
-      image: debian:12
-      options: --platform linux/arm64
+    runs-on: macos-14
     env:
       GHJK_TEST_E2E_TYPE: "local"
     steps:
@@ -83,12 +80,47 @@ jobs:
       - uses: denoland/setup-deno@v1
         with:
           deno-version: ${{ env.DENO_VERSION }}
-      - name: Cache deno dir
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.DENO_DIR }}
-          key: deno-linux-${{ hashFiles('**/deno.lock') }}
-      - run: deno task test
+      - uses: docker/setup-buildx-action@v3
+      - uses: actions-hub/docker/cli@master
+        env:
+          SKIP_LOGIN: true
+      - shell: bash
+        env:
+          TAG: test-image
+        run: |
+          docker buildx build --network=host --build-arg DENO_VERSION=$DENO_VERSION -t $TAG -f - .<<"DFILE"
+            ARG DENO_VERSION=1.42.1
+            FROM denoland/deno:bin-1.42.1 AS deno
+            FROM debian:12
+            COPY --from=deno /deno /usr/local/bin/deno
+            RUN set -eux; \
+                apt-get update; \
+                apt install --no-install-recommends --assume-yes \
+                # ambient deps \
+                # TODO: explicit libarchive \
+                zstd \
+                tar \
+                # TODO: explicit cc \
+                build-essential \
+                # test deps \
+                bash \
+                fish \
+                zsh \
+                # asdf deps \
+                git \
+                curl \
+                xz-utils \
+                unzip \
+                ca-certificates \
+                ;
+            WORKDIR /ghjk
+            COPY . .
+            ENV GHJK_TEST_E2E_TYPE=local
+            ENTRYPOINT deno task test
+          DFILE
+
+          docker run -it --rm $TAG
+
 
   test-action:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
                 gh_action/.*.js
             )$
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.27.0
+    rev: 0.28.2
     hooks:
       - id: check-dependabot
       - id: check-github-workflows

--- a/check.ts
+++ b/check.ts
@@ -7,6 +7,7 @@ import { $ } from "./utils/mod.ts";
 const files = (await Array.fromAsync(
   $.path(import.meta.url).parentOrThrow().expandGlob("**/*.ts", {
     exclude: [
+      "play.ts",
       ".ghjk/**",
       ".deno-dir/**",
     ],

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "test": "GHJK_LOG=debug deno test --parallel --unstable-worker-options --unstable-kv -A tests/*",
+    "test": "deno test --parallel --unstable-worker-options --unstable-kv -A tests/*",
     "cache": "deno cache deps/*",
     "check": "deno run -A check.ts"
   },

--- a/ports/cpy_bs.ts
+++ b/ports/cpy_bs.ts
@@ -147,6 +147,7 @@ export class Port extends PortBase {
     }
     const { installVersion, platform } = args;
     const arch = platform.arch;
+    let postfix = "pgo+lto-full";
     let os;
     switch (platform.os) {
       case "windows":
@@ -157,6 +158,9 @@ export class Port extends PortBase {
         // but it breaks python extensions support so we
         // must use glibc
         os = "unknown-linux-gnu";
+        if (arch == "aarch64") {
+          postfix = "lto-full";
+        }
         break;
       case "darwin":
         os = "apple-darwin";
@@ -165,7 +169,7 @@ export class Port extends PortBase {
         throw new Error(`unsupported: ${platform}`);
     }
     const urls = [
-      `https://github.com/${this.repoOwner}/${this.repoName}/releases/download/${tag}/cpython-${installVersion}+${tag}-${arch}-${os}-pgo+lto-full.tar.zst`,
+      `https://github.com/${this.repoOwner}/${this.repoName}/releases/download/${tag}/cpython-${installVersion}+${tag}-${arch}-${os}-${postfix}.tar.zst`,
     ];
     await Promise.all(
       urls.map(dwnUrlOut)

--- a/ports/meta_cli_ghrel.ts
+++ b/ports/meta_cli_ghrel.ts
@@ -75,6 +75,9 @@ export class Port extends GithubReleasePort {
       default:
         throw new Error(`unsupported: ${platform}`);
     }
+    if (platform.os == "linux" && platform.arch) {
+      throw new Error(`unsupported: ${platform}`);
+    }
     return [
       this.releaseArtifactUrl(
         installVersion,

--- a/ports/meta_cli_ghrel.ts
+++ b/ports/meta_cli_ghrel.ts
@@ -75,7 +75,7 @@ export class Port extends GithubReleasePort {
       default:
         throw new Error(`unsupported: ${platform}`);
     }
-    if (platform.os == "linux" && platform.arch) {
+    if (platform.os == "linux" && platform.arch == "aarch64") {
       throw new Error(`unsupported: ${platform}`);
     }
     return [

--- a/tests/ports.ts
+++ b/tests/ports.ts
@@ -139,6 +139,7 @@ const cases: CustomE2eTestCase[] = [
       // executrable
       ? `which meta && wasmedge --version`
       : `meta --version && wasmedge --version`,
+    ignore: Deno.build.os == "linux" && Deno.build.arch == "aarch64",
   },
   // 77 meg +
   {

--- a/tests/ports.ts
+++ b/tests/ports.ts
@@ -13,6 +13,10 @@ import type {
   PortsModuleSecureConfig,
 } from "../modules/ports/types.ts";
 
+console.log({
+  build: Deno.build,
+});
+
 type CustomE2eTestCase = Omit<E2eTestCase, "ePoints" | "tsGhjkfileStr"> & {
   ePoint: string;
   installConf: InstallConfigFat | InstallConfigFat[];

--- a/tests/ports.ts
+++ b/tests/ports.ts
@@ -12,10 +12,7 @@ import type {
   InstallConfigFat,
   PortsModuleSecureConfig,
 } from "../modules/ports/types.ts";
-
-console.log({
-  build: Deno.build,
-});
+import { testTargetPlatform } from "./utils.ts";
 
 type CustomE2eTestCase = Omit<E2eTestCase, "ePoints" | "tsGhjkfileStr"> & {
   ePoint: string;
@@ -143,7 +140,7 @@ const cases: CustomE2eTestCase[] = [
       // executrable
       ? `which meta && wasmedge --version`
       : `meta --version && wasmedge --version`,
-    ignore: Deno.build.os == "linux" && Deno.build.arch == "aarch64",
+    ignore: testTargetPlatform == "linux/aarch64",
   },
   // 77 meg +
   {

--- a/tests/test.Dockerfile.dockerignore
+++ b/tests/test.Dockerfile.dockerignore
@@ -1,3 +1,4 @@
 .git
 .vscode
+tests/
 *.md


### PR DESCRIPTION
Fixes the `cpy_bs` bug and adds linux/arm CI jobs to catch such bugs.

The `cpy_bs` port on linux/arm doesn't find the right url to download. This is due to the fact that it goes for pgo+lto binaries by default but upstream doesn't provide such optimized binaries for this target.

Note, the `custom-macos` runner is used for the new jobs as arm linux runners are not available and the github macos runners aren't docker enabled due to licencing issues.

### Checklist

- [x] The change come with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
