### PR TITLE
fix: nightly CI issue

### DIFF
--- a/.ghjk/lock.json
+++ b/.ghjk/lock.json
@@ -5,8 +5,14 @@
     "ports": {
       "version": "0",
       "configResolutions": {
+        "bciqay4m4kmzfduj5t2clgejxgpe5zwper6lyyaxt7rhbjalaqd32nhq": {
+          "version": "2.34.1",
+          "buildDepConfigs": {},
+          "portRef": "git_aa@0.1.0",
+          "specifiedVersion": false
+        },
         "bciqjlw6cxddajjmznoemlmnu7mgbbm7a3hfmnd2x5oivwajmiqui5ey": {
-          "version": "v0.2.63",
+          "version": "v0.2.64",
           "buildDepConfigs": {},
           "portRef": "act_ghrel@0.1.0",
           "specifiedVersion": false
@@ -15,16 +21,16 @@
           "version": "3.7.1",
           "buildDepConfigs": {
             "cpy_bs_ghrel": {
-              "version": "3.12.3",
+              "version": "3.12.4",
               "buildDepConfigs": {
                 "tar_aa": {
-                  "version": "1.35",
+                  "version": "1.34",
                   "buildDepConfigs": {},
                   "portRef": "tar_aa@0.1.0",
                   "specifiedVersion": false
                 },
                 "zstd_aa": {
-                  "version": "v1.5.6,",
+                  "version": "v1.4.8,",
                   "buildDepConfigs": {},
                   "portRef": "zstd_aa@0.1.0",
                   "specifiedVersion": false
@@ -39,16 +45,16 @@
           "specifiedVersion": false
         },
         "bciqij3g6mmbjn4a6ps4eipcy2fmw2zumgv5a3gbxycthroffihwquoi": {
-          "version": "3.12.3",
+          "version": "3.12.4",
           "buildDepConfigs": {
             "tar_aa": {
-              "version": "1.35",
+              "version": "1.34",
               "buildDepConfigs": {},
               "portRef": "tar_aa@0.1.0",
               "specifiedVersion": false
             },
             "zstd_aa": {
-              "version": "v1.5.6,",
+              "version": "v1.4.8,",
               "buildDepConfigs": {},
               "portRef": "zstd_aa@0.1.0",
               "specifiedVersion": false
@@ -58,13 +64,13 @@
           "specifiedVersion": false
         },
         "bciqj4p5hoqweghbuvz52rupja7sqze34z63dd62nz632c5zxikv6ezy": {
-          "version": "1.35",
+          "version": "1.34",
           "buildDepConfigs": {},
           "portRef": "tar_aa@0.1.0",
           "specifiedVersion": false
         },
         "bciqe6fwheayositrdk7rkr2ngdr4wizldakex23tgivss7w6z7g3q3y": {
-          "version": "v1.5.6,",
+          "version": "v1.4.8,",
           "buildDepConfigs": {},
           "portRef": "zstd_aa@0.1.0",
           "specifiedVersion": false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,6 +66,6 @@ jobs:
         env: 
           GHJKFILE: ./examples/protoc/ghjk.ts
       - run: |
-          cd examples/protoc
+          cd examples/tasks
           . $(ghjk print share-dir-path)/env.sh
-          protoc --version
+          ghjk x hey

--- a/ports/cargobi.ts
+++ b/ports/cargobi.ts
@@ -58,14 +58,15 @@ export default function conf(config: CargobiInstallConf) {
   const out: InstallConfigFat = {
     ...readGhVars(),
     ...confValidator.parse(thisConf),
-    buildDepConfigs: {
-      [std_ports.rust_rustup.name]: thinInstallConfig(rust({
-        profile: "minimal",
-        ...rustConfOverride,
-      })),
-    },
     port: manifest,
   };
+  if (rustConfOverride) {
+    out.buildDepConfigs = {
+      [std_ports.rust_rustup.name]: thinInstallConfig(rust({
+        ...rustConfOverride,
+      })),
+    };
+  }
   return out;
 }
 

--- a/ports/cargobi.ts
+++ b/ports/cargobi.ts
@@ -22,6 +22,7 @@ import * as std_ports from "../modules/ports/std.ts";
 import {
   ghConfValidator,
   GithubReleasesInstConf,
+  readGhVars,
 } from "../modules/ports/ghrel.ts";
 import rust, { RustInstallConf } from "./rust.ts";
 
@@ -55,6 +56,7 @@ export type CargobiInstallConf =
 export default function conf(config: CargobiInstallConf) {
   const { rustConfOverride, ...thisConf } = config;
   const out: InstallConfigFat = {
+    ...readGhVars(),
     ...confValidator.parse(thisConf),
     buildDepConfigs: {
       [std_ports.rust_rustup.name]: thinInstallConfig(rust({

--- a/ports/cmake.ts
+++ b/ports/cmake.ts
@@ -25,7 +25,7 @@ import * as ports from "./mod.ts";
  *
  */
 export default function conf(
-  config: InstallConfigSimple,
+  config: InstallConfigSimple = {},
 ): InstallConfigFat[] {
   /*
     The universal macOS cmake build downloaded by asdf crashes

--- a/ports/rust.ts
+++ b/ports/rust.ts
@@ -70,8 +70,14 @@ export type RustInstallConf =
   & InstallConfigSimple
   & zod.input<typeof confValidator>;
 
+/**
+ * Uses {@link import("./rustup.ts").conf} to install a rust toolchain.
+ *
+ * Defaults to the minimal profile installation of
+ */
 export default function conf(config: RustInstallConf = {}) {
   return {
+    profile: "minimal",
     ...config,
     port: manifest,
   };

--- a/utils/mod.ts
+++ b/utils/mod.ts
@@ -201,7 +201,7 @@ let requestBuilder;
 try {
   requestBuilder = new dax.RequestBuilder()
     .showProgress(Deno.stderr.isTerminal())
-    .timeout(Deno.env.get("GHJK_REQ_TIMEOUT") as any ?? "1m");
+    .timeout(Deno.env.get("GHJK_REQ_TIMEOUT") as any ?? "5m");
 } catch (err) {
   throw new Error(
     `invalid timeout param on GHJK_REQ_TIMEOUT: ${
@@ -425,6 +425,7 @@ export async function downloadFile(
 
   await $.request(url)
     .header(headers)
+    .timeout(undefined)
     .pipeToPath(tmpFilePath, { create: true, mode });
 
   await $.path(downloadPath).ensureDir();


### PR DESCRIPTION
- Fixes `test-action` job in nightly runner
- Fixes `cargobi` port not properly reading GITHUB_TOKEN
- Adds default param for `cmake` port config

#### Migration notes

No changes required. 

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
