### PR TITLE
fix: filter packages in pipi port

### DIFF
--- a/modules/ports/pipi.ts
+++ b/modules/ports/pipi.ts
@@ -1,0 +1,51 @@
+import { logger, semver } from "../../port.ts";
+import { ListAllArgs } from "./types.ts";
+
+export type PackageMetadataSimple = {
+  files: [{ filename: string; "requires-python"?: string }];
+  versions: string[];
+};
+
+export function resolveCompatibleVersions(
+  args: ListAllArgs,
+  metadata: PackageMetadataSimple,
+) {
+  throw new Error("TODO: inject buildDepConfigs in ListAllargs");
+  
+  const pythonDep = args.config.buildDepConfigs!.cpy_bs_ghrel as {
+    version: string;
+  };
+  const pythonVersion = semver.parseRange(pythonDep.version);
+  const versions = [];
+
+  for (const file of metadata.files) {
+    const match = file.filename.match(/(\d+\.\d+\.\d+.*)\.tar\.gz/);
+
+    if (
+      match &&
+      testPythonCompablity(pythonVersion, file["requires-python"])
+    ) {
+      versions.push(match[1]);
+    }
+  }
+
+  return versions;
+}
+
+function testPythonCompablity(version: semver.Range, required?: string) {
+  if (!required) return true;
+
+  return required.split(",")
+    .map((v) => v.replaceAll(" ", ""))
+    .every((v) => testVersionSpecifier(version, v));
+}
+
+function testVersionSpecifier(version: semver.Range, specifier: string) {
+  const negate = specifier.startsWith("!=");
+  const specifierRange = semver.parseRange(
+    negate ? specifier.slice(2) : specifier,
+  );
+  const result = semver.rangeIntersects(version, specifierRange);
+
+  return negate ? !result : result;
+}

--- a/ports/pipi.ts
+++ b/ports/pipi.ts
@@ -17,6 +17,10 @@ import {
 } from "../port.ts";
 import cpy_bs from "./cpy_bs.ts";
 import * as std_ports from "../modules/ports/std.ts";
+import {
+  PackageMetadataSimple,
+  resolveCompatibleVersions,
+} from "../modules/ports/pipi.ts";
 
 export const manifest = {
   ty: "denoWorker@v1" as const,
@@ -51,11 +55,9 @@ export class Port extends PortBase {
       `https://pypi.org/simple/${conf.packageName}/`,
     )
       .header("Accept", "application/vnd.pypi.simple.v1+json")
-      .json() as {
-        versions: string[];
-      };
+      .json() as PackageMetadataSimple;
 
-    return metadata.versions;
+    return resolveCompatibleVersions(args, metadata);
   }
 
   latestStable(args: ListAllArgs): Promise<string> {


### PR DESCRIPTION
<!--
Pull requests are squashed and merged using:
- their title as the commit message
- their description as the commit body

Having a good title and description is important for the users to get readable changelog.
-->

<!-- 1. Explain WHAT the change is about -->

Fixes #98. ([MET 645](https://linear.app/metatypedev/issue/MET-645/unsupported-python-version-for-pipi-port))

<!-- 2. Explain WHY the change cannot be made simpler -->

<!-- 3. Explain HOW users should update their code -->

#### Migration notes

...

- [ ] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
