### PR TITLE
fix: shim spillover

### DIFF
--- a/ports/dup_test.ts
+++ b/ports/dup_test.ts
@@ -1,0 +1,64 @@
+//! Test port to produce duplicate exec basenames without env var conflicts
+
+import type {
+  DownloadArgs,
+  InstallArgs,
+  InstallConfigSimple,
+} from "../src/deno_ports/mod.ts";
+import {
+  $,
+  ALL_ARCH,
+  ALL_OS,
+  osXarch,
+  PortBase,
+  zod,
+} from "../src/deno_ports/mod.ts";
+import { std_fs } from "../src/deno_utils/mod.ts";
+
+const manifest = {
+  ty: "denoWorker@v1" as const,
+  name: "dup_test",
+  version: "0.1.0",
+  moduleSpecifier: import.meta.url,
+  platforms: osXarch([...ALL_OS], [...ALL_ARCH]),
+};
+
+const confValidator = zod.object({
+  output: zod.string(),
+});
+
+export type DupTestInstallConf =
+  & InstallConfigSimple
+  & zod.infer<typeof confValidator>;
+
+export default function conf(config: DupTestInstallConf) {
+  return {
+    ...config,
+    port: manifest,
+  };
+}
+
+export class Port extends PortBase {
+  override execEnv() {
+    // no env vars to avoid conflicts across multiple installs
+    return {};
+  }
+
+  listAll() {
+    return ["dup_test"];
+  }
+
+  override async download(args: DownloadArgs) {
+    const conf = confValidator.parse(args.config);
+    await $.path(args.downloadPath).join("bin", "dup").writeText(
+      `#!/bin/sh\necho ${conf.output}`,
+      { mode: 0o700 },
+    );
+  }
+
+  override async install(args: InstallArgs) {
+    const installPath = $.path(args.installPath);
+    await $.removeIfExists(installPath);
+    await std_fs.copy(args.downloadPath, args.installPath);
+  }
+}

--- a/src/deno_utils/mod.ts
+++ b/src/deno_utils/mod.ts
@@ -17,6 +17,7 @@ import {
   zod,
   zod_val_err,
 } from "./deps.ts";
+export { std_fs } from "./deps.ts";
 import logger, { isColorfulTty } from "./logger.ts";
 // NOTE: only use type imports only when getting stuff from "./sys_deno"
 import type { OsEnum } from "../sys_deno/ports/types.ts";

--- a/src/ghjk/systems/envs.rs
+++ b/src/ghjk/systems/envs.rs
@@ -426,7 +426,8 @@ pub async fn reduce_and_cook_to(
     let env_vars = posix::cook(
         ecx,
         &reduced_recipe,
-        env_name.unwrap_or(env_key),
+        env_key,
+        env_name,
         env_dir,
         create_shell_loaders,
     )


### PR DESCRIPTION
- Allows colliding shims by using secondary shim dirs
- Duplicate shims also get aliases like `myExec-myEnv-2`

---

- [x] The change comes with new or modified tests
- [ ] Hard-to-understand functions have explanatory comments
- [ ] End-user documentation is updated to reflect the change
